### PR TITLE
Breaking: Change argument of PEnvSchema#parseProcessEnv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,11 @@
 
 ## Upcoming
 
-Feature: Support for logging environment variables in PEnvSchema#parseProcessEnv.
+Feature: Support comma-separated `string[]`-valued variables as `p.stringArray`
 
-Breaking: Change argument of PEnvSchema#parseProcessEnv from [processEnv] to [{log, processEnv}].
+Feature: Support for logging environment variables in PEnvSchema#parseProcessEnv
+
+Breaking: Change argument of PEnvSchema#parseProcessEnv from [processEnv] to [{log, processEnv}]
 
 ## carnesen-p-env-0.0.0 (2022-03-13)
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
 		"release": "carnesen-dev release",
 		"start": "node lib",
 		"test": "./scripts/test.sh",
-		"unit-test": "NODE_ENV=test jest src",
-		"unit-test:coverage": "npm run unit-test -- --coverage"
+		"unit-test": "NODE_ENV=test jest src --coverage"
 	},
 	"devDependencies": {
 		"@carnesen/dev": "^0.2.1",

--- a/src/__tests__/string-array.test.ts
+++ b/src/__tests__/string-array.test.ts
@@ -1,0 +1,10 @@
+import { p } from '..';
+
+describe('stringArray', () => {
+	const type = p.stringArray({ default: [] });
+
+	it('splits the environment value on ","', () => {
+		const parsed = type.parse('foo,bar,baz');
+		expect(parsed).toEqual(['foo', 'bar', 'baz']);
+	});
+});

--- a/src/external.ts
+++ b/src/external.ts
@@ -2,13 +2,15 @@ import { PEnvParsedProcessEnv, PEnvSchema } from './p-env-schema';
 import { PEnvNumber } from './p-env-number';
 import { PEnvString } from './p-env-string';
 import { PEnvBoolean } from './p-env-boolean';
+import { PEnvStringArray } from './p-env-string-array';
 
+export * from './p-env-abstract-type';
 export * from './p-env-boolean';
 export * from './p-env-error';
 export * from './p-env-number';
 export * from './p-env-schema';
+export * from './p-env-string-array';
 export * from './p-env-string';
-export * from './p-env-abstract-type';
 export * from './process-env';
 export * from './safe-parse-result';
 
@@ -17,18 +19,21 @@ const integer = PEnvNumber.createInteger;
 const number = PEnvNumber.create;
 const port = PEnvNumber.createPort;
 const string = PEnvString.create;
+const stringArray = PEnvStringArray.create;
 const schema = PEnvSchema.create;
 
-type TypeOfParsed<Schema> = Schema extends PEnvSchema<infer Shape>
+/** Helper for inferring the return type of schema.parse */
+type TypeOfParsedProcessEnv<Schema> = Schema extends PEnvSchema<infer Shape>
 	? PEnvParsedProcessEnv<Shape>
 	: unknown;
 
 export {
 	boolean,
-	TypeOfParsed as infer,
+	TypeOfParsedProcessEnv as infer,
 	integer,
 	number,
 	port,
 	schema,
 	string,
+	stringArray,
 };

--- a/src/p-env-abstract-type.ts
+++ b/src/p-env-abstract-type.ts
@@ -7,7 +7,11 @@ import {
 } from './safe-parse-result';
 
 export interface PEnvTypeConfig<ParsedValue = unknown> {
+	/** Value used for this variable if it's not present in the environment and
+	 * NODE_ENV !== "production" */
 	default: ParsedValue;
+	/** If true, use the default value even when NODE_ENV === "production". If
+	 * false or undefined, this variable _must_ be provided in the environment */
 	optional?: boolean;
 }
 
@@ -18,10 +22,10 @@ export type ParseOptions = {
 };
 
 export abstract class PEnvAbstractType<Parsed = unknown> {
-	constructor(readonly config: PEnvTypeConfig<Parsed>) {}
+	protected constructor(readonly config: PEnvTypeConfig<Parsed>) {}
 
 	/** Parse an environment variable value if one is available */
-	abstract _safeParse(envValue: string): SafeParseResult<Parsed>;
+	protected abstract _safeParse(envValue: string): SafeParseResult<Parsed>;
 
 	parse(envValue: string | undefined, options: ParseOptions = {}): Parsed {
 		const safeParsed = this.safeParse(envValue, options);

--- a/src/p-env-boolean.ts
+++ b/src/p-env-boolean.ts
@@ -8,11 +8,11 @@ import {
 export type PEnvBooleanConfig = PEnvTypeConfig<boolean>;
 
 export class PEnvBoolean extends PEnvAbstractType<boolean> {
-	constructor(readonly config: PEnvBooleanConfig) {
+	private constructor(readonly config: PEnvBooleanConfig) {
 		super(config);
 	}
 
-	_safeParse(envValue: string): SafeParseResult<boolean> {
+	protected _safeParse(envValue: string): SafeParseResult<boolean> {
 		switch (envValue.trim().toLowerCase()) {
 			case '1':
 			case 'yes':
@@ -30,6 +30,9 @@ export class PEnvBoolean extends PEnvAbstractType<boolean> {
 		}
 	}
 
+	/** Factory for boolean-valued environment variables. "1", "true", "yes" (and
+	 * their upper-case variations) parse to `true`. "0", "false", and "no" (and
+	 * their upper-case variations) parse to `false` */
 	static create(options: PEnvBooleanConfig): PEnvBoolean {
 		return new PEnvBoolean(options);
 	}

--- a/src/p-env-error.ts
+++ b/src/p-env-error.ts
@@ -1,1 +1,2 @@
+/** Error class thrown by code in this package */
 export class PEnvError extends Error {}

--- a/src/p-env-number.ts
+++ b/src/p-env-number.ts
@@ -6,20 +6,30 @@ import {
 	safeParseSuccess,
 } from './safe-parse-result';
 
+/** Maximum allowed value for a "port" variable */
 export const PORT_MAXIMUM = 65535;
+/** Minimum allowed value for a "port" variable */
 export const PORT_MINIMUM = 0;
 
+/** Configuration options for the `integer` value factory */
 export interface PEnvIntegerConfig extends PEnvTypeConfig<number> {
+	/** If provided, values greater than this are considered invalid */
 	maximum?: number;
+	/** If provided, values less than this are considered invalid */
 	minimum?: number;
 }
 
+/** Configuration options for the `port` value factory */
+export type PEnvPortConfig = PEnvIntegerConfig;
+
+/** Configuration options for the `number` value factory */
 export interface PEnvNumberConfig extends PEnvIntegerConfig {
+	/** If true, non-integer values are considered invalid */
 	integer?: boolean;
 }
 
 export class PEnvNumber extends PEnvAbstractType<number> {
-	constructor(readonly config: PEnvNumberConfig) {
+	private constructor(readonly config: PEnvNumberConfig) {
 		super(config);
 
 		if (config.maximum) {
@@ -55,7 +65,7 @@ export class PEnvNumber extends PEnvAbstractType<number> {
 		}
 	}
 
-	_safeParse(envValue: string): SafeParseResult<number> {
+	protected _safeParse(envValue: string): SafeParseResult<number> {
 		const failureToConvert = safeParseFailure("can't be converted to a number");
 		const trimmed = envValue.trim();
 		if (trimmed.length === 0) {
@@ -92,15 +102,20 @@ export class PEnvNumber extends PEnvAbstractType<number> {
 		return safeParseSuccess(parsed);
 	}
 
+	/** Factory for `number`-valued environment variables */
 	static create(config: PEnvNumberConfig): PEnvNumber {
 		return new PEnvNumber(config);
 	}
 
+	/** Factory for integer-valued (`number`) environment variables. */
 	static createInteger(config: PEnvIntegerConfig): PEnvNumber {
 		return new PEnvNumber({ ...config, integer: true });
 	}
 
-	static createPort(config: PEnvIntegerConfig): PEnvNumber {
+	/** Factory for integer-valued (`number`) environment variables between 0 and
+	 * 65535, suitable for usage as a server [IP
+	 * port](https://en.wikipedia.org/wiki/Port_(computer_networking)) */
+	static createPort(config: PEnvPortConfig): PEnvNumber {
 		const maximum =
 			typeof config.maximum === 'number' ? config.maximum : PORT_MAXIMUM;
 		if (maximum > PORT_MAXIMUM) {

--- a/src/p-env-schema.ts
+++ b/src/p-env-schema.ts
@@ -26,8 +26,9 @@ export type PEnvParseProcessEnvOptions = {
 };
 
 export class PEnvSchema<Shape extends AnyPEnvShape> {
-	constructor(readonly shape: Shape) {}
+	private constructor(readonly shape: Shape) {}
 
+	/** Parse the global process.env, throwing on any parse/validation error */
 	parseProcessEnv(
 		options: PEnvParseProcessEnvOptions = {},
 	): PEnvParsedProcessEnv<Shape> {
@@ -38,6 +39,7 @@ export class PEnvSchema<Shape extends AnyPEnvShape> {
 		throw new PEnvError(safeParsed.reason);
 	}
 
+	/** Parse the global process.env, returning a SafeParseResult container */
 	safeParseProcessEnv(
 		options: PEnvParseProcessEnvOptions = {},
 	): SafeParseResult<PEnvParsedProcessEnv<Shape>> {
@@ -77,6 +79,7 @@ export class PEnvSchema<Shape extends AnyPEnvShape> {
 		return safeParseSuccess(parsed as PEnvParsedProcessEnv<Shape>);
 	}
 
+	/** Factory for process.env schema declarations */
 	static create<NewShape extends AnyPEnvShape>(
 		shape: NewShape,
 	): PEnvSchema<NewShape> {

--- a/src/p-env-string-array.ts
+++ b/src/p-env-string-array.ts
@@ -1,0 +1,20 @@
+import { PEnvAbstractType, PEnvTypeConfig } from './p-env-abstract-type';
+import { SafeParseResult, safeParseSuccess } from './safe-parse-result';
+
+export type PEnvStringArrayConfig = PEnvTypeConfig<string[]>;
+
+export class PEnvStringArray extends PEnvAbstractType<string[]> {
+	private constructor(readonly config: PEnvStringArrayConfig) {
+		super(config);
+	}
+
+	protected _safeParse(envValue: string): SafeParseResult<string[]> {
+		return safeParseSuccess(envValue.split(','));
+	}
+
+	/** Factory for `string[]`-valued environment variables. The raw environment
+	 * value is split on "," e.g. `FOO=bar,baz` parses to ["bar", "baz"] */
+	static create(options: PEnvStringArrayConfig): PEnvStringArray {
+		return new PEnvStringArray(options);
+	}
+}

--- a/src/p-env-string.ts
+++ b/src/p-env-string.ts
@@ -7,11 +7,12 @@ import {
 } from './safe-parse-result';
 
 export interface PEnvStringConfig extends PEnvTypeConfig<string> {
+	/** If provided, a value longer than this is considered invalid */
 	maxLength?: number;
 }
 
 export class PEnvString extends PEnvAbstractType<string> {
-	constructor(readonly config: PEnvStringConfig) {
+	private constructor(readonly config: PEnvStringConfig) {
 		super(config);
 		if (config.maxLength) {
 			if (config.maxLength < 0) {
@@ -25,7 +26,7 @@ export class PEnvString extends PEnvAbstractType<string> {
 		}
 	}
 
-	_safeParse(envValue: string): SafeParseResult<string> {
+	protected _safeParse(envValue: string): SafeParseResult<string> {
 		if (
 			typeof this.config.maxLength === 'number' &&
 			envValue.length > this.config.maxLength
@@ -37,6 +38,7 @@ export class PEnvString extends PEnvAbstractType<string> {
 		return safeParseSuccess(envValue);
 	}
 
+	/** Factory for `string`-valued environment variables */
 	static create(options: PEnvStringConfig): PEnvString {
 		return new PEnvString(options);
 	}

--- a/src/process-env.ts
+++ b/src/process-env.ts
@@ -4,6 +4,7 @@
 /** Expected type of globalThis.process.env */
 export type ProcessEnv = Record<string, string | undefined>;
 
+/** Safely load the global variable process.env defaulting to {} */
 export function loadProcessEnv(): ProcessEnv {
 	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 	return (globalThis as any).process?.env || {};

--- a/src/safe-parse-result.ts
+++ b/src/safe-parse-result.ts
@@ -3,6 +3,7 @@ export type SafeParseSuccess<Value = unknown> = {
 	value: Value;
 };
 
+/** Factory for SafeParseSuccess objects */
 export function safeParseSuccess<Value = unknown>(
 	value: Value,
 ): SafeParseSuccess<Value> {
@@ -14,6 +15,7 @@ export function safeParseSuccess<Value = unknown>(
 
 export type SafeParseFailure = { success: false; reason: string };
 
+/** Factory for SafeParseFailure objects */
 export function safeParseFailure(reason: string): SafeParseFailure {
 	return {
 		success: false,
@@ -21,6 +23,7 @@ export function safeParseFailure(reason: string): SafeParseFailure {
 	};
 }
 
+/** success-discriminated union of possible safeParse results */
 export type SafeParseResult<ParsedValue = unknown> =
 	| SafeParseSuccess<ParsedValue>
 	| SafeParseFailure;


### PR DESCRIPTION
Was [processEnv]. Is [{logger, processEnv}]

Support comma-separated `string[]`-valued variables as `p.stringArray`

Support for logging environment variables in PEnvSchema#parseProcessEnv
