### PR TITLE
Change protected method name from _safeParse to safeParseInternal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+Breaking: Change PEnvAbstractType method name from _safeParse to safeParseInternal. This is only a breaking change if you're using a custom PEnvAbstractType subclass.
+
+Fix: Redact environment value in error messages and logs if the type has `config.secret === true`.
+
 ## carnesen-p-env-0.3.0 (2022-03-20)
 
 Breaking: Tweak the logger API one more time for real. Now it's e.g. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "@carnesen/p-env",
 			"version": "0.3.0",
 			"license": "MIT",
+			"dependencies": {
+				"@carnesen/p-env": "^0.3.0"
+			},
 			"devDependencies": {
 				"@carnesen/dev": "^0.2.1",
 				"@carnesen/tsconfig": "^0.5.0",
@@ -704,6 +707,14 @@
 			"resolved": "https://registry.npmjs.org/@carnesen/error-like/-/error-like-0.1.0.tgz",
 			"integrity": "sha512-0F8sUvfCFRO4xxJX9aVsjm3GiPnsyxnDY0Nwwd424sayzPWr0bkxRFoXjTlAU9UtJ9u8Ae2XFNKs4uCfbn0Jqg==",
 			"dev": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@carnesen/p-env": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@carnesen/p-env/-/p-env-0.3.0.tgz",
+			"integrity": "sha512-Btv2RfFBmC7wRHuDQ8ycIbRtBKFsaIsA2Cx42kUNMsZ2f6kB2vDnStR1o2JVx1fE3NsZSnLzu5p+Z3P3DakKhA==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -7496,6 +7507,11 @@
 			"resolved": "https://registry.npmjs.org/@carnesen/error-like/-/error-like-0.1.0.tgz",
 			"integrity": "sha512-0F8sUvfCFRO4xxJX9aVsjm3GiPnsyxnDY0Nwwd424sayzPWr0bkxRFoXjTlAU9UtJ9u8Ae2XFNKs4uCfbn0Jqg==",
 			"dev": true
+		},
+		"@carnesen/p-env": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@carnesen/p-env/-/p-env-0.3.0.tgz",
+			"integrity": "sha512-Btv2RfFBmC7wRHuDQ8ycIbRtBKFsaIsA2Cx42kUNMsZ2f6kB2vDnStR1o2JVx1fE3NsZSnLzu5p+Z3P3DakKhA=="
 		},
 		"@carnesen/tsconfig": {
 			"version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"release": "carnesen-dev release",
 		"start": "node lib",
 		"test": "./scripts/test.sh",
-		"unit-test": "NODE_ENV=test jest src --coverage"
+		"unit-test": "NODE_ENV=test jest src --coverage",
+		"unit-test:watch": "npm run unit-test -- --watch"
 	},
 	"devDependencies": {
 		"@carnesen/dev": "^0.2.1",
@@ -43,5 +44,8 @@
 		"!src/**/__tests__",
 		"lib",
 		"!lib/**/__tests__"
-	]
+	],
+	"dependencies": {
+		"@carnesen/p-env": "^0.3.0"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ import { p } from '@carnesen/p-env';
 const appEnvSchema = p.schema({
 	APP_NAME: p.string({ default: 'my-app' }),
 	PORT: p.port({ default: 8080, optional: true }),
-	SECRET_KEY: p.string({ default: '' }),
+	SECRET_KEY: p.string({ default: '', secret: true }),
 	STRICT_MODE: p.boolean({ default: false, optional: true }),
 });
 
@@ -26,7 +26,7 @@ type AppEnv = p.infer<typeof appEnvSchema>;
 const appEnv: AppEnv = appEnvSchema.parseProcessEnv({ logger: console });
 // APP_NAME=my-app
 // PORT=8080
-// SECRET_KEY=xxxxxxx
+// SECRET_KEY=<redacted>
 // STRICT_MODE=false
 
 console.log(appEnv.APP_NAME);
@@ -36,6 +36,10 @@ console.log(appEnv.APP_NAME);
 Every field in the schema must have a default value. When `NODE_ENV` _is not_ `"production"` the default value will be used if a value is not provided in the process environment. When `NODE_ENV` _is_ `"production"`, the default value is ignored unless that field has `optional: true`.
 
 The schema `safeParseProcessEnv` method returns `{ success: true, value: <the parsed process.env>}` if there are no validation/parse errors or `{ success: false, reason: <validation/parse error messages>}` otherwise. The schema `parseProcessEnv` method returns the parsed result value or throws if there's a validation/parse error.
+
+## API
+
+This primary documentation for this package's API is its rich, strict types along with their associated TypeDoc strings viewable in your IDE by hovering over a symbol. All exports are named. The primary export is the `p` namespace object. To create your own custom field type, extend `PEnvAbstractType`.
 
 ## Related
 

--- a/src/example.ts
+++ b/src/example.ts
@@ -5,7 +5,7 @@ import { p } from '.';
 const appEnvSchema = p.schema({
 	APP_NAME: p.string({ default: 'my-app' }),
 	PORT: p.port({ default: 8080, optional: true }),
-	SECRET_KEY: p.string({ default: '' }),
+	SECRET_KEY: p.string({ default: '', secret: true }),
 	STRICT_MODE: p.boolean({ default: false, optional: true }),
 });
 
@@ -14,7 +14,7 @@ type AppEnv = p.infer<typeof appEnvSchema>;
 const appEnv: AppEnv = appEnvSchema.parseProcessEnv({ logger: console });
 // APP_NAME=my-app
 // PORT=8080
-// SECRET_KEY=xxxxxxx
+// SECRET_KEY=<redacted>
 // STRICT_MODE=false
 
 console.log(appEnv.APP_NAME);

--- a/src/external.ts
+++ b/src/external.ts
@@ -1,18 +1,10 @@
+/** The exports of this module are exported in the main index as the primary
+ * external API, "p" */
 import { PEnvParsedProcessEnv, PEnvSchema } from './p-env-schema';
 import { PEnvNumber } from './p-env-number';
 import { PEnvString } from './p-env-string';
 import { PEnvBoolean } from './p-env-boolean';
 import { PEnvStringArray } from './p-env-string-array';
-
-export * from './p-env-abstract-type';
-export * from './p-env-boolean';
-export * from './p-env-error';
-export * from './p-env-loader';
-export * from './p-env-number';
-export * from './p-env-schema';
-export * from './p-env-string-array';
-export * from './p-env-string';
-export * from './safe-parse-result';
 
 const boolean = PEnvBoolean.create;
 const integer = PEnvNumber.createInteger;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-import * as mod from './external';
-export * from './external';
-export { mod as p };
-export default mod;
+export * as p from './external';
+
+export * from './p-env-abstract-type';
+export * from './p-env-boolean';
+export * from './p-env-error';
+export * from './p-env-loader';
+export * from './p-env-number';
+export * from './p-env-schema';
+export * from './p-env-string-array';
+export * from './p-env-string';
+export * from './safe-parse-result';

--- a/src/p-env-boolean.ts
+++ b/src/p-env-boolean.ts
@@ -12,7 +12,7 @@ export class PEnvBoolean extends PEnvAbstractType<boolean> {
 		super(config);
 	}
 
-	protected _safeParse(envValue: string): SafeParseResult<boolean> {
+	protected safeParseInternal(envValue: string): SafeParseResult<boolean> {
 		switch (envValue.trim().toLowerCase()) {
 			case '1':
 			case 'yes':

--- a/src/p-env-number.ts
+++ b/src/p-env-number.ts
@@ -65,7 +65,7 @@ export class PEnvNumber extends PEnvAbstractType<number> {
 		}
 	}
 
-	protected _safeParse(envValue: string): SafeParseResult<number> {
+	protected safeParseInternal(envValue: string): SafeParseResult<number> {
 		const failureToConvert = safeParseFailure("can't be converted to a number");
 		const trimmed = envValue.trim();
 		if (trimmed.length === 0) {

--- a/src/p-env-schema.ts
+++ b/src/p-env-schema.ts
@@ -25,6 +25,8 @@ export type PEnvSchemaConfig = {
 	logger?: PEnvLogger;
 };
 
+const REDACTED_VALUE = '<redacted>';
+
 export class PEnvSchema<Shape extends AnyPEnvShape> {
 	private constructor(
 		readonly shape: Shape,
@@ -61,14 +63,18 @@ export class PEnvSchema<Shape extends AnyPEnvShape> {
 				parsed[name] = result.value;
 				if (logger && logger.log) {
 					const loggedValue = valueType.config.secret
-						? 'xxxxxxx'
+						? REDACTED_VALUE
 						: result.value;
 					logger.log(`${name}=${loggedValue}`);
 				}
 			} else {
+				// !result.success
 				const parts = [name];
 				if (typeof envValue !== 'undefined') {
-					parts.push(`value "${envValue}"`);
+					const loggedEnvValue = valueType.config.secret
+						? REDACTED_VALUE
+						: envValue;
+					parts.push(`value "${loggedEnvValue}"`);
 				}
 				parts.push(result.reason);
 				const reason = parts.join(' ');

--- a/src/p-env-string-array.ts
+++ b/src/p-env-string-array.ts
@@ -8,7 +8,7 @@ export class PEnvStringArray extends PEnvAbstractType<string[]> {
 		super(config);
 	}
 
-	protected _safeParse(envValue: string): SafeParseResult<string[]> {
+	protected safeParseInternal(envValue: string): SafeParseResult<string[]> {
 		return safeParseSuccess(envValue.split(','));
 	}
 

--- a/src/p-env-string.ts
+++ b/src/p-env-string.ts
@@ -26,7 +26,7 @@ export class PEnvString extends PEnvAbstractType<string> {
 		}
 	}
 
-	protected _safeParse(envValue: string): SafeParseResult<string> {
+	protected safeParseInternal(envValue: string): SafeParseResult<string> {
 		if (
 			typeof this.config.maxLength === 'number' &&
 			envValue.length > this.config.maxLength


### PR DESCRIPTION
Redact environment value in error messages and logs too. Previously we
only redacted the successfully parsed value.
